### PR TITLE
Neufassung im Zuge der e.V. Umgründung

### DIFF
--- a/Geschaeftsordnung.md
+++ b/Geschaeftsordnung.md
@@ -1,50 +1,53 @@
 # Geschäftsordnung der Deutschen Schachjugend
 
-**Stand 2019**
+**Stand 22.08.2020**
 
 #### § 1 Inhalt
 
-Die Geschäftsordnung beinhaltet in Ergänzung zur Jugendordnung der DSJ
-Richtlinien zur geregelten Arbeit und zur Abgrenzung der Aufgabenbereiche
-innerhalb der DSJ, ihrer Führungsgremien, der Arbeitskreise und Ausschüsse.
+Die Geschäftsordnung beinhaltet in Ergänzung zur Satzung der DSJ Richtlinien zur geregelten Arbeit und zur Abgrenzung der Aufgabenbereiche innerhalb der DSJ, ihrer Organe, der Arbeitskreise und Arbeitsgruppen.
 
 #### § 2 Gremien
 
-(1) Oberstes Führungsgremium der DSJ ist die Jugendversammlung. Sie ist im Rahmen der Jugendordnung zuständig für alle Angelegenheiten der DSJ. Sie beschließt insbesondere über grundsätzliche Fragen des Jugendschachs und bestimmt die Richtlinien für die Tätigkeit des Vorstandes. Ihre Aufgaben sind in der Jugendordnung festgelegt.
+(1) Oberstes Organ der DSJ ist die Jugendversammlung. Sie ist im Rahmen der Satzung zuständig für alle Angelegenheiten der DSJ. Sie beschließt insbesondere über grundsätzliche Fragen des Jugendschachs und bestimmt die Richtlinien für die Tätigkeit des Vorstandes. Ihre Aufgaben sind in der Satzung festgelegt.
 
-
-(2)	Zwischen den Jugendversammlungen ist der Vorstand zuständig für alle Angelegenheiten der DSJ. Er setzt insbesondere die Beschlüsse der Jugendversammlung um, entwickelt im Rahmen der Jugendordnung und des Haushalts unter Beachtung bestehender Grundsatzbeschlüsse und Konzeptionen neue Aktivitäten in allen Bereichen des Jugendschachs und koordiniert die Tätigkeit der Mitglieder des Vorstandes.
+(2) Zwischen den Jugendversammlungen ist der Vorstand zuständig für alle Angelegenheiten der DSJ. Er setzt insbesondere die Beschlüsse der Jugendversammlung um, entwickelt im Rahmen der Satzung und des Haushalts unter Beachtung bestehender Grundsatzbeschlüsse und Konzeptionen neue Aktivitäten in allen Bereichen des Jugendschachs und koordiniert die Tätigkeit der Mitglieder des Vorstandes.
 
 (3) Der Geschäftsführende Vorstand ist zuständig für die allgemeine laufende Verwaltung der DSJ. Dazu zählen insbesondere Angelegenheiten der Haushaltsführung, der Sitzungsvorbereitung und der Außenkontakte im Rahmen des laufenden Schriftverkehrs. Die Entscheidung über grundsätzliche Fragen bleibt dem Vorstand bzw. der Jugendversammlung vorbehalten.
 
-(4) 
+(4) Zur Unterstützung des Vorstandes und zur Erfüllung seiner Aufgaben werden die Arbeitskreise Mädchenschach, Allgemeine Jugendarbeit, Öffentlichkeitsarbeit, Schulschach und Spielbetrieb eingerichtet. Für sie gilt:
 
-a) Zur Unterstützung des Vorstandes und zur Erfüllung seiner Aufgaben werden die Arbeitskreise Mädchenschach, Allgemeine Jugendarbeit, Öffentlichkeitsarbeit, Schulschach und Spielbetrieb eingerichtet. Ihre Aufgaben sind unter § 3 näher beschrieben.
+1. Die Arbeitskreise werden von dem jeweils zuständigen Vorstandsmitglied als ihrem Vorsitzenden geleitet. Der Arbeitskreisvorsitzende koordiniert die in seinem Aufgabenbereich anfallenden Arbeiten zwischen den Arbeitskreismitgliedern. Er ist
+an Beschlüsse der Jugendversammlung und des Vorstandes gebunden und ihnen gegenüber verantwortlich für seinen Aufgabenbereich; dies gilt auch hinsichtlich der Tätigkeit der weiteren Arbeitskreismitglieder.
+2. Die Arbeit der Arbeitskreise geschieht in der Regel schriftlich. Bei Bedarf kann der Arbeitskreisvorsitzende mit Genehmigung des Vorstandes Sitzungen einberufen. Die Einladung mit Tagesordnung ist allen Vorstandsmitgliedern zur Kenntnis zu bringen. Der 1. Vorsitzende oder die stellvertretenden Vorsitzenden sowie der Mädchenreferent und die Jugendsprecher haben das Recht, an allen Arbeitskreissitzungen teilzunehmen.
 
-b) Die Arbeitskreise werden von dem jeweils zuständigen Vorstandsmitglied als ihrem Vorsitzenden geleitet. Der Arbeitskreisvorsitzende koordiniert die in seinem Aufgabenbereich anfallenden Arbeiten zwischen den Arbeitskreismitgliedern. Er ist an Beschlüsse der Jugendversammlung und des Vorstandes gebunden und ihnen gegenüber verantwortlich für seinen Aufgabenbereich; dies gilt auch hinsichtlich der Tätigkeit der weiteren Arbeitskreismitglieder.
+(5) Die Referenten des DSB haben das Recht mit beratender Stimme an den Sitzungen der Arbeitskreise teilzunehmen. Dieses Recht haben
 
-c) Soweit es zur Erfüllung der in dem jeweiligen Aufgabengebiet anfallenden Arbeiten erforderlich ist, beruft der Vorstand für die Dauer eines Jahres auf  Vorschlag der Arbeitskreisvorsitzenden die weiteren Mitglieder des jeweiligen Arbeitskreises. Vor der Konstituierung des Arbeitskreises sind die Landesverbände zu hören und ist ihnen Gelegenheit zu geben, eigene Vorschläge einzureichen. Arbeitskreismitglieder können mit Zwei-Drittel-Mehrheit vom Vorstand abberufen werden.
+1. der Referent für Frauenschach für den Arbeitskreis Mädchenschach,
+2. der Bundesturnierdirektor für den Arbeitskreis Spielbetrieb,
+3. der Referent für Öffentlichkeitsarbeit für den Arbeitskreis Öffentlichkeitsarbeit und
+4. der Referent für Breitensport für den Arbeitskreis Allgemeine Jugendarbeit.
 
-	
-d) Die Arbeit der Arbeitskreise geschieht in der Regel schriftlich. Bei Bedarf kann der Arbeitskreisvorsitzende mit Genehmigung des Vorstandes Sitzungen einberufen. Die Einladung mit Tagesordnung ist allen Vorstandsmitgliedern zur Kenntnis zu bringen. Der 1. Vorsitzende oder die stellvertretenden Vorsitzenden sowie der Mädchenreferent und die Jugendsprecher haben das Recht, an allen Arbeitskreissitzungen teilzunehmen.
+(6) Die Jugendversammlung und der Vorstand können zur Erfüllung besonderer Aufgaben Arbeitsgruppen einrichten sowie weitere Beauftragte einsetzen. Zuständigkeit, Aufgaben und Amtsdauer sind mit der Einsetzung festzulegen. Über Zweifelsfragen entscheidet der Vorstand.
 
-(5) Die Jugendversammlung ernennt in den Jahren mit ungerader Endziffer für die Dauer von 2 Jahren einen Beauftragten für Leistungssport, dessen Aufgaben in §3 dieser Geschäfttsordnung festgelegt sind.
+(7) Zur Entwicklung von langfristigen Strategien für die Jugendarbeit als Gesamtes oder für einzelne Teilbereiche der Jugendarbeit sowie zum intensiven Meinungsaustausch sollen regelmäßig Strategietagungen, Workshops oder Themenwerkstätten
+stattfinden, zu denen der Vorstand Vertreter der Landesverbände einlädt. Der Vorstand hat das Recht, zu diesen Veranstaltungen auch Vertreter der übrigen Ebenen der Jugendarbeit und aus anderen Organisationen einzuladen.
 
-(6) Die Jugendversammlung ernennt in den Jahren mit ungerader Endziffer für die Dauer von 2 Jahren einen Beauftragten für Dopingbekämpfung und -prävention, dessen Aufgaben in § 3 dieser Geschäftsordnung festgelegt sind.
+#### § 3 Berufung von Arbeitskreismitgliedern und von bestimmten Beauftragten
+(1) Soweit es zur Erfüllung der in dem jeweiligen Aufgabengebiet anfallenden Arbeiten erforderlich ist, beruft der Vorstand für die Dauer eines Jahres auf Vorschlag der Arbeitskreisvorsitzenden die weiteren Mitglieder des jeweiligen Arbeitskreises. Vor der Konstituierung des Arbeitskreises sind die Landesverbände zu hören und ist ihnen Gelegenheit zu geben, eigene Vorschläge einzureichen. Arbeitskreismitglieder können mit Zwei-Drittel-Mehrheit vom Vorstand abberufen werden.
 
-(7) Die Jugendversammlung und der Vorstand können zur Erfüllung besonderer Aufgaben Fachausschüsse einrichten sowie Projektgruppen und weitere Beauftragte einsetzen. Zuständigkeit, Aufgaben und Amtsdauer sind mit der Einsetzung festzulegen. Über Zweifelsfragen entscheidet der Vorstand.
+(2) Die Jugendversammlung ernennt in den Jahren mit ungerader Endziffer für die Dauer von 2 Jahren einen Beauftragten für Leistungssport, dessen Aufgaben in § 4 festgelegt sind.
 
-(8) Zur Entwicklung von langfristigen Strategien für die Jugendarbeit als Gesamtes oder für einzelne Teilbereiche der Jugendarbeit sowie zum intensiven Meinungsaustausch sollen regelmäßig Strategietagungen, Workshops, Themenwerkstätten stattfinden, zu denen der Vorstand Vertreter der Landesverbände einlädt. Der Vorstand hat das Recht, zu diesen Veranstaltungen auch Vertreter der übrigen Ebenen der Jugendarbeit und aus anderen Organisationen einzuladen.
+(3) Die Jugendversammlung ernennt in den Jahren mit ungerader Endziffer für die Dauer von 2 Jahren einen Beauftragten für Dopingbekämpfung und -prävention, dessen Aufgaben in § 4 festgelegt sind.
 
-#### § 3 Aufgabenbereiche der Vorstandsmitglieder und der Arbeitskreise
+(4) Der Vorstand ernennt in den Jahren, in denen ein ordentlicher Kongress des Deutschen Schachbundes stattfindet, drei Mitglieder der Gemeinsamen Kommission DSB und DSJ.
 
-(1) Der 1. Vorsitzende vertritt die DSJ nach außen, insbesondere gegenüber dem Deutschen Schachbund, der Deutschen Sportjugend und gegenüber Jugendvertretern ausländischer Schachföderationen. Er hat die Stellung eines gesetzlichen Vertreters i.S.v. § 26 Abs. 2 BGB. Er ergreift die Initiative hinsichtlich der Vorhaben der DSJ und koordiniert die Tätigkeit der Mitglieder des Vorstands und der sonstigen Mitarbeiter der DSJ. In Eilfällen trifft er vorläufige Maßnahmen und entscheidet an Stelle des Vorstandes und des Geschäftsführenden Vorstands, wenn eine Entscheidung des Geschäftsführenden Vorstands nicht rechtzeitig herbeigeführt werden kann.
+#### § 4 Aufgabenbereiche der Vorstandsmitglieder, der Beauftragten und der Arbeitskreise
+(1) Der 1. Vorsitzende vertritt die DSJ nach außen, insbesondere gegenüber dem Deutschen Schachbund, der Deutschen Sportjugend und gegenüber Jugendvertretern ausländischer Schachföderationen. Er hat die Stellung eines gesetzlichen Vertreters i.S.v. § 26 Abs. 2
+BGB. Er ergreift die Initiative hinsichtlich der Vorhaben der DSJ und koordiniert die Tätigkeit der Mitglieder des Vorstands und der sonstigen Mitarbeiter der DSJ. In Eilfällen trifft er vorläufige Maßnahmen und entscheidet an Stelle des Vorstandes und des Geschäftsführenden Vorstands, wenn eine Entscheidung des Geschäftsführenden Vorstands nicht rechtzeitig herbeigeführt werden kann.
 
-(2) Die stellvertretenden Vorsitzenden vertreten im Außenverhältnis die DSJ i.S.v. § Abs. 2 BGB neben dem 1. Vorsitzenden. In Absprache mit dem Vorstand sollen
-ihnen bestimmte Sachgebiete zur dauernden selbstständigen Bearbeitung übertragen werden. Der nach § 9.4 der Jugendordnung bestimmte 2. Vorsitzende vertritt als weiterer Vertreter der DSJ diese im Bundeskongress des Deutschen Schachbundes und nimmt die Aufgaben des 1. Vorsitzenden bei dessen Verhinderung wahr.
+(2) Die stellvertretenden Vorsitzenden vertreten im Außenverhältnis die DSJ i.S.v. § 26 Abs. 2 BGB neben dem 1. Vorsitzenden. In Absprache mit dem Vorstand sollen ihnen bestimmte Sachgebiete zur dauernden selbstständigen Bearbeitung übertragen werden.
 
 (3) Der Finanzreferent nimmt alle finanziellen Belange der DSJ nach Maßgabe der Finanzordnung wahr. Er überwacht die Einhaltung des Haushaltsplans und berät den Vorstand und den Geschäftsführenden Vorstand in allen Fragen mit finanziellen Auswirkungen.
-
 
 (4) Der Mädchenreferent und der von ihm geleitete Arbeitskreis Mädchenschach sind zuständig für alle Belange des Mädchenschachs. Er entwickelt Initiativen zur allgemeinen Förderung des Mädchenschachs auf allen Ebenen. Zur Erfüllung seiner Aufgaben hat der Mädchenreferent in allen Arbeitskreisen ein Mitwirkungsrecht.
 
@@ -52,112 +55,99 @@ ihnen bestimmte Sachgebiete zur dauernden selbstständigen Bearbeitung übertrag
 
 (6) Der Beauftragte für Leistungssport vertritt im Rahmen der „Konzeption zur Leistungssportförderung im Deutschen Schachbund“ die DSJ beim DSB als Mitglied in der Kommission Leistungssport.
 
-(7) Der Beauftragte für Dopingbekämpfung und -prävention bereitet die Dopingthematik jugend- und verbandsgerecht auf. In Absprache mit dem Vorstand pflegt er Kontakt mit dem DSB und der Nationalen Anti Doping Agentur (NADA). Er koordiniert in Kooperation mit dem Beauftragten des DSB und dem Turnierverantwortlichen
-Kontrollmaßnahmen im Bereich der DSJ. Die Verantwortlichkeit der Nationalen Spielleiter für Angelegenheiten des Spielbetriebs bleibt unberührt
+(7) Der Beauftragte für Dopingbekämpfung und -prävention bereitet die Dopingthematik jugend- und verbandsgerecht auf. In Absprache mit dem Vorstand pflegt er Kontakt mit dem DSB und der Nationalen Anti Doping Agentur (NADA). Er koordiniert in Kooperation mit dem Beauftragten des DSB und dem Turnierverantwortlichen Kontrollmaßnahmen im Bereich der DSJ. Die Verantwortlichkeit der Nationalen Spielleiter für Angelegenheiten des Spielbetriebs bleibt unberührt.
 
 (8) Der Referent für Öffentlichkeitsarbeit und der von ihm geleitete Arbeitskreis für Öffentlichkeitsarbeit sind zuständig für die Pressearbeit der DSJ gegenüber der Schachpresse, der allgemeinen Presse und anderen Medien, für die Erstellung und Verbreitung eines Mitteilungsorgans der DSJ, für die Erstellung von Materialien für die Presse- und Öffentlichkeitsarbeit, für die Erstellung von Werbeträgern und für die Imagepflege der DSJ.
 
 (9) Der Referent für Schulschach und der von ihm geleitete Arbeitskreis Schulschach sind zuständig für das gesamte Schulschach. Dazu zählen insbesondere die Förderung und Durchführung von Modellmaßnahmen für die Zusammenarbeit zwischen Schule und Verein, die Durchführung von Schulschachwettbewerben auf Bundesebene und die Durchführung von Fortbildungsmaßnahmen für Lehrer.
 
-(10) Die Nationalen Spielleiter und der von ihnen geleitete Arbeitskreis Spielbetrieb sind zuständig für den gesamten Spielbetrieb der Jungen und Mädchen auf Bundesebene nach Maßgabe der DSJ-Spielordnung. Sie geben jährlich der Jugendversammlung bekannt, welcher der beiden jeweils zuständig für die Austragung der von der DSJ ausgeschriebenen Turniere ist. Der Vorstand bestimmt drei Mitglieder des Arbeitskreises zum Spielaussschuss, dem durch Beschluss des Vorstands und nach Maßgabe der DSJ-Spielordnung spezielle Aufgaben des Spielbetriebs übertragen werden können.
+(10) Die Nationalen Spielleiter und der von ihnen geleitete Arbeitskreis Spielbetrieb sind zuständig für den gesamten Spielbetrieb der Jungen und Mädchen auf Bundesebene nach Maßgabe der DSJ-Spielordnung. Sie geben jährlich der Jugendversammlung bekannt, welcher der beiden jeweils zuständig für die Austragung der von der DSJ ausgeschriebenen Turniere ist. Der Vorstand bestimmt drei Mitglieder des Arbeitskreises zum Spielausschuss, dem durch Beschluss des Vorstands und nach Maßgabe der DSJ-Spielordnung spezielle Aufgaben des Spielbetriebs übertragen werden können.
 
-(11) Die Bundesjugendsprecher vertreten die Wünsche und Interessen der jugendlichen Schachspieler. Sie haben das Recht, jederzeit gegenüber allen Gremien der DSJ und deren Mitglieder Anregungen, Kritik und Beschwerden zu äußern. Förmliche Beschwerden müssen vom zuständigen Vorstandsmitglied schriftlich beschieden werden
+(11) Die Bundesjugendsprecher vertreten die Wünsche und Interessen der jugendlichen Schachspieler. Sie haben das Recht, jederzeit gegenüber allen Gremien der DSJ und deren Mitgliedern Anregungen, Kritik und Beschwerden zu äußern. Förmliche Beschwerden müssen vom zuständigen Vorstandsmitglied schriftlich beschieden werden.
 
-#### § 4 DSJ-Geschäftsführer
+#### § 5 DSJ Geschäftsführer
 
-(1) Der DSJ-Geschäftsführer wird als hauptamtlicher Mitarbeiter in der DSB-Geschäftsstelle beschäftigt. Er unterstützt den Vorstand bei der Erfüllung seiner Aufgaben, insbesondere in den Bereichen Verwaltung, Spitzensportförderung, Kontakt zu Sponsoren und Erarbeitung von Konzeptentwürfen. Das Nähere regelt der Vorstand durch Beschluss; über Einzelfragen entscheidet der 1. Vorsitzende.
+(1) Der DSJ-Geschäftsführer wird als hauptamtlicher Mitarbeiter beschäftigt. Er unterstützt den Vorstand bei der Erfüllung seiner Aufgaben, insbesondere in den Bereichen Verwaltung, Spitzensportförderung, Kontakt zu Sponsoren und Erarbeitung von Konzeptentwürfen. Das Nähere regelt der Vorstand durch Beschluss; über Einzelfragen entscheidet der 1. Vorsitzende.
 
 (2) Durch Vorstandsbeschluss können dem Geschäftsführer Aufgaben in den Arbeitskreisen übertragen werden.
 
 (3) Der DSJ-Geschäftsführer und andere hauptamtliche Mitarbeiter der DSJ können nicht gleichzeitig ein Vorstandsamt auf DSJ-Ebene ausüben. Sie können als Beauftragte eingesetzt werden, andere Ehrenämter können sie ohne Stimmrecht ausüben.
 
-#### § 5 Sitzungsordnung
 
-(1) Geltungsbereich
 
-Die Sitzungsordnung gilt für die Jugendversammlung, die Vorstandssitzungen und für die Sitzungen von Ausschüssen, Kommissionen und sonstigen Gremien der DSJ.
+#### § 6 Sitzungsordnung
 
-(2) Form und Dauer
+(1) Die Sitzungsordnung gilt für die Jugendversammlung, die Vorstandssitzungen und für die Sitzungen von Arbeitskreisen, Arbeitsgruppen und sonstigen Gremien der DSJ.
 
-a) Sitzungen von Vorstand oder Ausschuss für Spitzensport, bei denen Entscheidungen zu treffen sind, die wesentliche Interessen der DSJ oder einzelner ihrer
-	Mitglieder berühren, sollen möglichst nicht im Umlaufverfahren erfolgen.
+(2) Hinsichtlich der Art und Weise von Sitzungen gilt das Folgende: 
 
-b) Beschlussfassende Tagungen sollen eine Tagungszeit von acht Stunden je Tag nicht überschreiten.
+1. Beschlüsse des Vorstands, bei denen Entscheidungen zu treffen sind, die wesentliche Interessen der DSJ oder einzelner ihrer Mitglieder berühren, sollen möglichst nicht im Umlaufverfahren erfolgen.
+2. Beschlussfassende Tagungen sollen eine Tagungszeit von acht Stunden je Tag nicht überschreiten.
+
 	
-(3) Versammlungsleiter
+(3) Die Leitung der Jugendversammlung obliegt einem Tagungsleiter, der vom Vorstand der DSJ vorgeschlagen und von der Jugendversammlung genehmigt wird. Vorstandssitzungen werden vom 1. Vorsitzenden der DSJ oder seinem Vertreter geleitet. 
 
-Die Leitung der Jugendversammlung obliegt einem Tagungsleiter, der vom Vorstand der DSJ vorgeschlagen und von der Jugendversammlung genehmigt wird. Vorstandssitzungen werden vom 1. Vorsitzenden der DSJ oder seinem Vertreter geleitet.
-
-(4) Eröffnung und Tagesordnung
-
-Der Versammlungsleiter eröffnet die Sitzung mit der Feststellung
+(4) Der Versammlungsleiter eröffnet die Sitzung mit der Feststellung
 
 1. der ordnungsgemäßen Einladung und Beschlussfähigkeit,
 2. der Stimmenzahlen, sodann folgen
 3. die Wahl des Protokollführers,
-4. die Genehmigung des Protokolls der vorausgegangenen Sitzung,
+4. die Genehmigung des Protokolls der vorausgegangenen
+Sitzung,
 5. die Beratung in der Reihenfolge der Tagesordnung.
-	
-Die Reihenfolge der Tagesordnungspunkte kann mit einfacher Stimmenmehrheit geändert werden. Maßgebend für die Stimmen der Mitgliedsorganisationen ist die Zahl der im Vorjahr (Stichtag 31.12.) an den DSB gemeldeten Jugendlichen.
+Die Reihenfolge der Tagesordnungspunkte kann mit einfacher Stimmenmehrheit geändert werden. Maßgebend für die Stimmen der Mitgliedsorganisationen ist die Zahl der im Vorjahr (Stichtag 31.12.) an den DSB gemeldeten jungen Menschen.
 
-(5) Redeordnung
+(5) Für Redebeiträge gilt:
 
-a) Kein Teilnehmer darf das Wort ergreifen, ohne es vorher beantragt und vom Versammlungsleiter erhalten zu haben.
-	
-b) Wortmeldungen erfolgen durch Handzeichen und sind in einer Rednerliste festzuhalten.
-	
-c) Die Reihenfolge der Redner richtet sich nach der Rednerliste, doch kann der Versammlungsleiter eine andere Reihenfolge bestimmen, wenn dies sachdienlich erscheint. Antragsteller und Berichterstatter können sowohl zu Beginn als auch am Ende der Beratung das Wort verlangen.
-	
-d) Zur Geschäftsordnung muss das Wort jederzeit gegeben werden, doch darf eine Rede nicht unterbrochen werden. Die Bemerkung zur Geschäftsordnung darf nicht länger als zwei Minuten dauern.
-	
-e) Zur persönlichen Bemerkung wird das Wort erst nach Schluss der Beratung erteilt.
-	
-f) Die Rednerzeit kann auf eine Höchstgrenze beschränkt werden. Überschreitet der Redner diese Höchstzeit, so kann ihm der Versammlungsleiter nach einmaliger Mahnung das Wort entziehen. Ist einem Redner das Wort entzogen,
-kann er es zu dem gleichen Gegenstand nicht noch einmal erhalten.
-Kein Redner darf zu einem Beratungspunkt ohne Zustimmung des Versammlungsleiters mehr als zweimal reden.
-	
-g) Der Versammlungsleiter kann Redner, die vom Verhandlungspunkt abschweifen, zur Sache rufen. Verletzt ein Teilnehmer die Ordnung, so hat der Versammlungsleiter diesen zur Ordnung zu rufen. Nach zweimaligem Anruf zur Sache oder zur Ordnung ist dem Redner das Wort zu entziehen.
-	
-h) Bei gröblicher Störung der Ordnung kann der Versammlungsleiter einen Teilnehmer von der Sitzung oder Versammlung ausschließen. Kommt der betreffende Teilnehmer dieser Aufforderung nicht nach, so ist die Sitzung zu unterbrechen oder aufzuheben.
+1. Kein Teilnehmer darf das Wort ergreifen, ohne es vorher beantragt und vom Versammlungsleiter erhalten zu haben.
+2. Wortmeldungen erfolgen durch Handzeichen und sind in einer Rednerliste festzuhalten.
+3. Die Reihenfolge der Redner richtet sich nach der Rednerliste, doch kann der Versammlungsleiter eine andere Reihenfolge bestimmen, wenn dies sachdienlich erscheint. Antragsteller und Berichterstatter können sowohl zu Beginn als auch am Ende der Beratung das Wort verlangen.
+4. Zur Geschäftsordnung muss das Wort jederzeit gegeben werden, doch darf eine Rede nicht unterbrochen werden. Die Bemerkung zur Geschäftsordnung darf nicht länger als zwei Minuten dauern.
+5. Zur persönlichen Bemerkung wird das Wort erst nach Schluss der Beratung erteilt.
+6. Die Rednerzeit kann auf eine Höchstgrenze beschränkt werden. Überschreitet der Redner diese Höchstzeit, so kann ihm der Versammlungsleiter nach einmaliger Mahnung das Wort entziehen. Ist einem Redner das Wort entzogen, kann er es zu dem gleichen Gegenstand nicht noch einmal erhalten. Kein Redner darf zu einem Beratungspunkt ohne Zustimmung des Versammlungsleiters mehr als zweimal reden.
+7. Der Versammlungsleiter kann Redner, die vom Verhandlungspunkt abschweifen, zur Sache rufen. Verletzt ein Teilnehmer die Ordnung, so hat der Versammlungsleiter diesen zur Ordnung zu rufen. Nach zweimaligem Anruf zur Sache oder zur Ordnung ist dem Redner das Wort zu entziehen.
+8. Bei grober Störung der Ordnung kann der Versammlungsleiter einen Teilnehmer von der Sitzung oder Versammlung ausschließen. Kommt der betreffende Teilnehmer dieser Aufforderung nicht nach, so ist die Sitzung zu unterbrechen oder aufzuheben.
 
-(6) Behandlung von Anträgen
+(6) Für die Behandlung von Anträgen gilt das Folgende:
 
-a) Jeder stimmberechtigte Teilnehmer kann die Teilung eines Antrages verlangen. Hierüber wird mit einfacher Mehrheit entschieden.
-	
-b) Ordnungsgemäß eingereichte Anträge können während der Versammlung im Laufe der Diskussion umformuliert bzw. geändert werden, ohne dass solche Änderungsvorschläge als Dringlichkeitsanträge behandelt werden.
-	
-c) Bei mehreren Anträgen über den gleichen Gegenstand ist zunächst über den weitestgehenden Antrag abzustimmen.
+1. Jeder stimmberechtigte Teilnehmer kann die Teilung eines
+Antrages verlangen. Hierüber wird mit einfacher Mehrheit
+entschieden.
+2. Ordnungsgemäß eingereichte Anträge können während der
+Versammlung im Laufe der Diskussion umformuliert bzw. geändert
+werden, ohne dass solche Änderungsvorschläge als
+Dringlichkeitsanträge behandelt werden.
+3. Bei mehreren Anträgen über den gleichen Gegenstand ist
+zunächst über den weitestgehenden Antrag abzustimmen.
 
-(7) Abstimmungsregeln
+(7) Hinsichtlich der Abstimmungen gilt das Folgende:
 
-a) Es wird vorbehaltlich der in der Jugendordnung vorgesehenen Fälle qualifizierter Mehrheit mit Mehrheit der abgegebenen gültigen Stimmen entschieden.
-	
-b) Es werden zunächst die Ja-Stimmen, dann die Nein-Stimmen und zuletzt die Stimmenthaltungen festgestellt.
-	
-c) Bei einfachen Abstimmungen werden zur Ermittlung des Ergebnisses die Stimmenthaltungen sowie die ungültigen Stimmen nicht mitgezählt. Falls eine qualifizierte Mehrheit erforderlich ist, zählen die Stimmenthaltungen sowie die ungültigen Stimmen als Nein-Stimmen.
-	
-d) Bei Gleichheit der abgegebenen Ja- und Nein-Stimmen gilt der Antrag als abgelehnt.
-	
-e) Auf Verlangen eines stimmberechtigten Teilnehmers ist geheim abzustimmen.
-	
-f) Zu einem durch Abstimmung erledigten Beratungspunkt darf in der gleichen Sitzung das Wort nicht mehr erteilt werden, es sei denn, dass der Beschluss mit der Jugendordnung, der Satzung des DSB oder anderen zwingenden Rechtsvorschriften unvereinbar ist.
+1. Es wird vorbehaltlich der in der Satzung vorgesehenen Fälle der
+Notwendigkeit einer qualifizierter Mehrheit mit Mehrheit der
+abgegebenen gültigen Stimmen entschieden.
+2. Es werden zunächst die Ja-Stimmen, dann die Nein-Stimmen und
+zuletzt die Stimmenthaltungen festgestellt.
+3. Bei einfachen Abstimmungen werden zur Ermittlung des
+Ergebnisses die Stimmenthaltungen sowie die ungültigen Stimmen nicht mitgezählt. Falls eine qualifizierte Mehrheit erforderlich ist, zählen die Stimmenthaltungen sowie die ungültigen Stimmen als Nein-Stimmen.
+4. Bei Gleichheit der abgegebenen Ja- und Nein-Stimmen gilt der Antrag als abgelehnt.
+5. Auf Verlangen eines stimmberechtigten Teilnehmers ist geheim abzustimmen.
+6. Zu einem durch Abstimmung erledigten Beratungspunkt darf in der gleichen Sitzung das Wort nicht mehr erteilt werden, es sei denn, dass der Beschluss mit der Satzung, der Satzung des DSB oder anderen zwingenden Rechtsvorschriften unvereinbar ist.
 
-(8) Niederschriften
+(8) Die Vorschriften bezüglich des Protokolls sind in § 28 der Satzung festgelegt.
 
-Die Vorschriften bezüglich des Protokolls sind in § 10 der Jugendordnung festgelegt.
+(9) Über die Auslegung der Sitzungsordnung entscheidet im Einzelfall der Versammlungsleiter.
 
-(9) Auslegung der Sitzungsordnung
+#### § 7 Arbeitsrichtlinien
 
-Über die Auslegung der Sitzungsordnung entscheidet im Einzelfall der Versammlungsleiter.
+(1) Sämtliche DSJ-Mitarbeiter sind gehalten, anfallende Arbeiten
+zügig zu erledigen.
 
-## § 6 Arbeitsrichtlinien
+(2) Ausscheidende DSJ-Mitarbeiter haben unverzüglich sämtliche
+Unterlagen und Materialien ihrem Nachfolger zu übergeben, ersatzweise dem 1. Vorsitzenden.
 
-(1) Sämtliche DSJ-Mitarbeiter sind gehalten, anfallende Arbeiten zügig zu erledigen.
+#### § 8 Zustimmungsvorbehalt
+Sofern die Vorschrift in § 2 Absatz 5 oder diese Vorschrift geändert, ergänzt oder aufgehoben werden, bedarf dies der Zustimmung des DSB.
 
-(2) Ausscheidende DSJ-Mitarbeiter haben unverzüglich sämtliche Unterlagen und Materialien ihrem Nachfolger zu übergeben, ersatzweise dem 1. Vorsitzenden.
-
-(3) Erforderliche Änderungen der Geschäftsordnung bedürfen eines Mehrheitsbeschlusses der Jugendversammlung.
-
-*Letzte Änderungen durch die Jugendversammlung 2019 in Potsdam*
+*Beschlossen durch die Jugendversammlung am 22.08.2020 in Magdeburg*
 
 


### PR DESCRIPTION
Inhaltliche Neuerungen sind im wesentlichen das in §2 Abs. 5 geregelte beratende Teilnahmerecht der zuständigen DSB-Referenten in den Arbeitskreisen
sowie die in Paragraph 3 Abs. 4 eingefügte Berufung von Mitgliedern der gemeinsamen Kommision DSB und DSJ.

Diese desweiteren redaktionell überarbeitete Geschäftsordnung wurde am 22. August 2020 auf der außerordentlichen Jugendversammlung in Magdeburg beschlossen.